### PR TITLE
条件式 お試し (cargo)

### DIFF
--- a/procon/conditional/Cargo.toml
+++ b/procon/conditional/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "conditional"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+proconio = "0.3.6"

--- a/procon/conditional/src/main.rs
+++ b/procon/conditional/src/main.rs
@@ -5,11 +5,14 @@ fn main() {
         x: i32,
         y: i32,
     }
-    if x > 0 && y > 0 {
-        println!("両方とも正の数です");
+
+    let judgement = if x > 0 && y > 0 {
+        "両方とも正の数です"
     } else if x > 0 || y > 0 {
-        println!("いずれかが正の数です");
+        "いずれかが正の数です"
     } else {
-        println!("終了");
-    }
+        "終了"
+    };
+
+    println!("{}", judgement);
 }

--- a/procon/conditional/src/main.rs
+++ b/procon/conditional/src/main.rs
@@ -3,9 +3,13 @@ use proconio::input;
 fn main() {
     input! {
         x: i32,
+        y: i32,
     }
-    if x < 100 {
-        println!("100未満です");
+    if x > 0 && y > 0 {
+        println!("両方とも正の数です");
+    } else if x > 0 || y > 0 {
+        println!("いずれかが正の数です");
+    } else {
+        println!("終了");
     }
-    println!("終了");
 }

--- a/procon/conditional/src/main.rs
+++ b/procon/conditional/src/main.rs
@@ -1,0 +1,11 @@
+use proconio::input;
+
+fn main() {
+    input! {
+        x: i32,
+    }
+    if x < 100 {
+        println!("100未満です");
+    }
+    println!("終了");
+}


### PR DESCRIPTION
### preparation
```
% cd procon
% cargo new conditional
```

### result
1. `cargo run`
1. 数値 x2 を入力
```
1 1
両方とも正の数です

1 0
いずれかが正の数です

0 0
終了
```

### ref
- https://zenn.dev/toga/books/rust-atcoder/viewer/08-if