### PR TITLE
アサートお試し (cargo)

### DIFF
--- a/procon/assertion/Cargo.toml
+++ b/procon/assertion/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "assertion"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+proconio = "0.3.6"

--- a/procon/assertion/src/main.rs
+++ b/procon/assertion/src/main.rs
@@ -1,0 +1,34 @@
+use proconio::input;
+
+fn main() {
+    input! {
+        x: i32,
+    }
+    assert!(
+        x > 0 && x <= 100,
+        "(Error!)100以下の正の整数を入力して下さい。{} は処理不可",
+        x
+    );
+
+    let is_fizz = if x % 3 == 0 {
+        true
+    } else {
+        false
+    };
+
+    let is_buzz = if x % 5 == 0 {
+        true
+    } else {
+        false
+    };
+
+    if is_fizz && is_buzz {
+        println!("fizzbuzz");
+    } else if is_fizz {
+        println!("fizz");
+    } else if is_buzz {
+        println!("buzz");
+    } else {
+        println!("{}", x);
+    };
+}


### PR DESCRIPTION
### preparation
```
% cd procon
% cargo new assertion
```

### result
1. `cargo run`
1. 数値 x1 を入力
```
3
fizz

5
buzz

15
fizzbuzz

16
16

1111
thread 'main' panicked at '(Error!)100以下の正の整数を入力して下さい。1111 は処理不可', src/main.rs:7:5
```

### ref
- https://zenn.dev/toga/books/rust-atcoder/viewer/10-assert
