### PR TITLE
パターンマッチ・タプルお試し (cargo run)

### DIFF
--- a/procon/pattern_match/Cargo.toml
+++ b/procon/pattern_match/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "pattern_match"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+proconio = "0.3.6"

--- a/procon/pattern_match/src/main.rs
+++ b/procon/pattern_match/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/procon/pattern_match/src/main.rs
+++ b/procon/pattern_match/src/main.rs
@@ -1,13 +1,23 @@
+use proconio::input;
+
 fn main() {
-    let tuple: (i32, i32, i32) = (
-        1,
-        2,
-        3,
+    input! {
+        a: i32,
+        b: i32,
+    }
+
+    let tuple: (i32, i32) = (
+        a,
+        b,
     );
     println!("タプルの1番目要素は、{}", tuple.0);
     println!("タプルの2番目要素は、{}", tuple.1);
-    println!("タプルの3番目要素は、{}", tuple.2);
 
-    let (x, y, z) = tuple;
-    println!("パターンマッチ: {},{},{}", x, y, z);
+    let (max, min) = if a > b {
+        (a, b)
+    } else {
+        (b, a)
+    };
+    assert!(max >= min);
+    println!("数値の大きさ降順にパターンマッチ: {},{}", max, min);
 }

--- a/procon/pattern_match/src/main.rs
+++ b/procon/pattern_match/src/main.rs
@@ -1,6 +1,13 @@
 fn main() {
-    let tuple: (i32, i32, i32) = (1, 2, 3);
+    let tuple: (i32, i32, i32) = (
+        1,
+        2,
+        3,
+    );
     println!("タプルの1番目要素は、{}", tuple.0);
     println!("タプルの2番目要素は、{}", tuple.1);
     println!("タプルの3番目要素は、{}", tuple.2);
+
+    let (x, y, z) = tuple;
+    println!("パターンマッチ: {},{},{}", x, y, z);
 }

--- a/procon/pattern_match/src/main.rs
+++ b/procon/pattern_match/src/main.rs
@@ -1,3 +1,6 @@
 fn main() {
-    println!("Hello, world!");
+    let tuple: (i32, i32, i32) = (1, 2, 3);
+    println!("タプルの1番目要素は、{}", tuple.0);
+    println!("タプルの2番目要素は、{}", tuple.1);
+    println!("タプルの3番目要素は、{}", tuple.2);
 }


### PR DESCRIPTION
### preparation
```
% cd procon
% cargo new pattern_match
```

### result
1. cargo run
1. 数値 x2 を入力
```
1 2
...
数値の大きさ降順にパターンマッチ: 2,1

2 1
...
数値の大きさ降順にパターンマッチ: 2,1
```

### ref
- https://zenn.dev/toga/books/rust-atcoder/viewer/11-tuple