### PR TITLE
フォーマット出力・配列 お試し (cargo run) 

### DIFF
--- a/procon/array/Cargo.toml
+++ b/procon/array/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "array"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+proconio = "0.3.6"

--- a/procon/array/src/main.rs
+++ b/procon/array/src/main.rs
@@ -21,4 +21,7 @@ fn main() {
         b,
         c
     );
+
+    println!("arr (one liner): {:?}", arr);
+    println!("arr (with start new line): {:#?}", arr);
 }

--- a/procon/array/src/main.rs
+++ b/procon/array/src/main.rs
@@ -10,4 +10,10 @@ fn main() {
     assert_eq!(arr[1], 10_i32);
     assert_eq!(arr[2], 100_i32);
     println!("assertion OK.");
+
+    let [a, b, c] = arr;
+    assert_eq!(a, 1);
+    assert_eq!(b, 10);
+    assert_eq!(c, 100);
+    println!("pattern match OK.");
 }

--- a/procon/array/src/main.rs
+++ b/procon/array/src/main.rs
@@ -1,0 +1,13 @@
+fn main() {
+    let arr: [i32; 3];
+    arr = [
+        1,
+        10,
+        100,
+    ];
+
+    assert_eq!(arr[0], 1_i32);
+    assert_eq!(arr[1], 10_i32);
+    assert_eq!(arr[2], 100_i32);
+    println!("assertion OK.");
+}

--- a/procon/array/src/main.rs
+++ b/procon/array/src/main.rs
@@ -15,5 +15,10 @@ fn main() {
     assert_eq!(a, 1);
     assert_eq!(b, 10);
     assert_eq!(c, 100);
-    println!("pattern match OK.");
+    println!(
+        "pattern match OK. {0}, {1}, {2}",
+        a,
+        b,
+        c
+    );
 }


### PR DESCRIPTION
### preparation
```
% cd procon
% cargo new array
```

### result
- `cargo run`
```
...
assertion OK.
pattern match OK. 1, 10, 100
arr (one liner): [1, 10, 100]
arr (with start new line): [
    1,
    10,
    100,
]
```

### ref
- https://zenn.dev/toga/books/rust-atcoder/viewer/12-array
- https://zenn.dev/toga/books/rust-atcoder/viewer/13-format