### PR TITLE
for お試し (cargo run)

### DIFF
--- a/procon/for_and_ref/Cargo.toml
+++ b/procon/for_and_ref/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "for_and_ref"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+proconio = "0.3.6"

--- a/procon/for_and_ref/src/main.rs
+++ b/procon/for_and_ref/src/main.rs
@@ -1,0 +1,11 @@
+fn main() {
+    let primes = [
+        10,
+        11,
+        12,
+    ];
+
+    for p in &primes {
+        println!("{}", p);
+    }
+}

--- a/procon/for_and_ref/src/main.rs
+++ b/procon/for_and_ref/src/main.rs
@@ -4,8 +4,16 @@ fn main() {
         11,
         12,
     ];
-
     for p in &primes {
         println!("{}", p);
+    }
+
+    let elements: [(i32, f64); 3] = [
+        (6, 12.0),
+        (7, 14.0),
+        (8, 16.0),
+    ];
+    for &(number, weight) in &elements {
+        println!("{}: {:.1}", number, weight);
     }
 }

--- a/procon/for_and_ref/src/main.rs
+++ b/procon/for_and_ref/src/main.rs
@@ -16,4 +16,18 @@ fn main() {
     for &(number, weight) in &elements {
         println!("{}: {:.1}", number, weight);
     }
+
+    let elem = (10, 20.0);
+    let (ref num, ref wt) = elem;
+    assert_eq!(*num, 10);
+    assert_eq!(*wt, 20.0);
+
+    // ref を使った for loop 式
+    for (ref number, ref weight) in &elements {
+        println!("{}: {:.1}", number, weight)
+    }
+    // 上記式の ref は省略可能
+    for (number, weight) in &elements {
+        println!("{}: {:.1}", number, weight)
+    }
 }

--- a/procon/reference_and_lifetime/src/main.rs
+++ b/procon/reference_and_lifetime/src/main.rs
@@ -1,8 +1,11 @@
 fn main() {
     let hoge: i8 = 100;
     let reference = &hoge;
-
     assert_eq!(*reference, 100_i8);
-
     println!("{:p}", reference);
+
+    let fuga: i8 = 100;
+    let ref reference_fuga = fuga;
+    assert_eq!(*reference_fuga, 100);
+    println!("{:p}", reference_fuga);
 }


### PR DESCRIPTION
### preparation
```
% cd procon
% cargo new for_and_ref
```

### result
`cargo run`
```
10
11
12
6: 12.0
7: 14.0
8: 16.0
```

### ref
- https://zenn.dev/toga/books/rust-atcoder/viewer/15-for
- https://zenn.dev/toga/books/rust-atcoder/viewer/16-pattern
- https://doc.rust-lang.org/std/fmt/
- 参照・参照外し
  - https://github.com/miolab/rust_book/pull/11
  - https://zenn.dev/toga/books/rust-atcoder/viewer/14-reference