### PR TITLE
参照・ライフタイム・ベクタ お試し (cargo run)

### DIFF
--- a/procon/mutable/Cargo.toml
+++ b/procon/mutable/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "mutable"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+proconio = "0.3.6"

--- a/procon/mutable/src/main.rs
+++ b/procon/mutable/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/procon/mutable/src/main.rs
+++ b/procon/mutable/src/main.rs
@@ -22,4 +22,16 @@ fn main() {
         sum_arr += num;
     }
     println!("{}", sum_arr);
+
+    // ベクタ
+    let empty_vector = Vec::<i32>::new();
+    println!("空ベクタ:\n{:?}", empty_vector);
+
+    let vector: Vec<i32> = vec![
+        1,
+        2,
+        3,
+    ];
+    assert_eq!(vector.len(), 3_usize);
+    println!("ベクタ:\n{:?}", vector);
 }

--- a/procon/mutable/src/main.rs
+++ b/procon/mutable/src/main.rs
@@ -68,4 +68,14 @@ fn main() {
             40,
         ]
     );
+
+    mutable_vector.pop();
+    assert_eq!(
+        mutable_vector,
+        vec![
+            10,
+            20,
+            30,
+        ]
+    );
 }

--- a/procon/mutable/src/main.rs
+++ b/procon/mutable/src/main.rs
@@ -86,6 +86,7 @@ fn main() {
         ]
     );
 
+    println!("ベクタ生成: 要素数と要素(i32)を入力...");
     input! {
         n: usize,
         input_vector: [i32; n],

--- a/procon/mutable/src/main.rs
+++ b/procon/mutable/src/main.rs
@@ -27,11 +27,14 @@ fn main() {
     let empty_vector = Vec::<i32>::new();
     println!("空ベクタ:\n{:?}", empty_vector);
 
-    let vector: Vec<i32> = vec![
+    let mut vector: Vec<i32> = vec![
         1,
         2,
         3,
     ];
     assert_eq!(vector.len(), 3_usize);
+    assert_eq!(vector[0], 1_i32);
+
+    vector[1] = 10;
     println!("ベクタ:\n{:?}", vector);
 }

--- a/procon/mutable/src/main.rs
+++ b/procon/mutable/src/main.rs
@@ -41,4 +41,31 @@ fn main() {
 
     vector[1] = 10;
     println!("ベクタ:\n{:?}", vector);
+
+    // 値の追加と削除
+    let mut mutable_vector = Vec::new();
+    assert_eq!(mutable_vector.len(), 0);
+
+    mutable_vector.push(10_i32);
+    mutable_vector.push(20);
+    mutable_vector.push(30);
+    assert_eq!(
+        mutable_vector,
+        vec![
+            10,
+            20,
+            30,
+        ]
+    );
+
+    mutable_vector.push(40);
+    assert_eq!(
+        mutable_vector,
+        vec![
+            10,
+            20,
+            30,
+            40,
+        ]
+    );
 }

--- a/procon/mutable/src/main.rs
+++ b/procon/mutable/src/main.rs
@@ -11,4 +11,15 @@ fn main() {
 
     mutable += 100;
     assert_eq!(mutable, 102);
+
+    let arr = [
+        1,
+        2,
+        3,
+    ];
+    let mut sum_arr = 0;
+    for num in &arr {
+        sum_arr += num;
+    }
+    println!("{}", sum_arr);
 }

--- a/procon/mutable/src/main.rs
+++ b/procon/mutable/src/main.rs
@@ -8,4 +8,7 @@ fn main() {
     mutable = 2;
     assert_eq!(mutable, 2);
     println!("{:p}", &mutable);
+
+    mutable += 100;
+    assert_eq!(mutable, 102);
 }

--- a/procon/mutable/src/main.rs
+++ b/procon/mutable/src/main.rs
@@ -27,6 +27,10 @@ fn main() {
     let empty_vector = Vec::<i32>::new();
     println!("空ベクタ:\n{:?}", empty_vector);
 
+    let empty_another_vector: Vec<u32>;
+    empty_another_vector = Vec::new();
+    println!("空ベクタ_v2:\n{:?}", empty_another_vector);
+
     let mut vector: Vec<i32> = vec![
         1,
         2,

--- a/procon/mutable/src/main.rs
+++ b/procon/mutable/src/main.rs
@@ -44,6 +44,11 @@ fn main() {
     vector[1] = 10;
     println!("ベクタ:\n{:?}", vector);
 
+    // for式での取り扱い
+    for i in &vector {
+        println!("{}", i);
+    }
+
     // 値の追加と削除
     let mut mutable_vector = Vec::new();
     assert_eq!(mutable_vector.len(), 0);

--- a/procon/mutable/src/main.rs
+++ b/procon/mutable/src/main.rs
@@ -1,3 +1,11 @@
 fn main() {
-    println!("Hello, world!");
+    let mut mutable: i32;
+
+    mutable = 1;
+    assert_eq!(mutable, 1);
+    println!("{:p}", &mutable);
+
+    mutable = 2;
+    assert_eq!(mutable, 2);
+    println!("{:p}", &mutable);
 }

--- a/procon/mutable/src/main.rs
+++ b/procon/mutable/src/main.rs
@@ -1,3 +1,5 @@
+use proconio::input;
+
 fn main() {
     let mut mutable: i32;
 
@@ -78,4 +80,10 @@ fn main() {
             30,
         ]
     );
+
+    input! {
+        n: usize,
+        input_vector: [i32; n],
+    }
+    println!("ベクタ生成:\n{:?}", input_vector);
 }


### PR DESCRIPTION
### preparation
```
% cd procon
% cargo new mutable
```

### result
1. cargo run
1. 数値 x2 を入力
```
...
ベクタ生成: 要素数と要素(i32)を入力...
3
1 2 3
ベクタ生成:
[1, 2, 3]
```

### ref
- https://zenn.dev/toga/books/rust-atcoder/viewer/17-mutable
- https://zenn.dev/toga/books/rust-atcoder/viewer/18-mutable-reference
- https://zenn.dev/toga/books/rust-atcoder/viewer/19-vector