### PR TITLE
[procon] A - ABC Preparation (cargo run)

### DIFF
--- a/procon/a_abc_preparation/Cargo.toml
+++ b/procon/a_abc_preparation/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "a_abc_preparation"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/procon/a_abc_preparation/Cargo.toml
+++ b/procon/a_abc_preparation/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+proconio = "0.3.6"

--- a/procon/a_abc_preparation/src/main.rs
+++ b/procon/a_abc_preparation/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/procon/a_abc_preparation/src/main.rs
+++ b/procon/a_abc_preparation/src/main.rs
@@ -1,3 +1,15 @@
+use proconio::input;
+
 fn main() {
-    println!("Hello, world!");
+    input! {
+        arr: [i32; 4],
+    }
+
+    let mut answer = 100;
+    for &i in &arr {
+        if i < answer {
+            answer =i;
+        }
+    }
+    println!("{}", answer);
 }


### PR DESCRIPTION
提出コード
https://atcoder.jp/contests/abc185/tasks/abc185_a

### result

```
% cd a_abc_preparation

% cargo run
...
5 99 4 3
3

% cargo run
88 88 99 1
1
```

### ref

- ベクタ https://zenn.dev/toga/books/rust-atcoder/viewer/19-vector
- https://github.com/miolab/rust_book/pull/13
- https://github.com/miolab/rust_book/pull/6