### PR TITLE
いろいろなloop お試し (cargo run)

### DIFF
--- a/procon/loops_various/Cargo.toml
+++ b/procon/loops_various/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "loops_various"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/procon/loops_various/Cargo.toml
+++ b/procon/loops_various/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+proconio = "0.3.6"

--- a/procon/loops_various/src/main.rs
+++ b/procon/loops_various/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/procon/loops_various/src/main.rs
+++ b/procon/loops_various/src/main.rs
@@ -22,7 +22,18 @@ fn main() {
         println!("{},", i)
     }
 
+    // while 式
+    println!("while:");
+    let mut a = 30;
+    let mut vec = Vec::new();
+    while a > 0 {
+        vec.push(a);
+        a /= 2;
+    }
+    println!("{:?},", vec);
+
     // loop 式
+    println!("loop:");
     loop {
         input! {
             x: i32,

--- a/procon/loops_various/src/main.rs
+++ b/procon/loops_various/src/main.rs
@@ -1,4 +1,7 @@
+use proconio::input;
+
 fn main() {
+    // for 式（continue, break）
     let arr = [11, 12, 13, 14, 15, 16];
     for &i in &arr {
         if i == 12 {
@@ -11,10 +14,36 @@ fn main() {
     }
     println!("done");
 
+    // `..` 演算子
     for i in 21..25 {
         println!("{},", i)
     }
     for i in 31..=35 {
         println!("{},", i)
     }
+
+    // loop 式
+    loop {
+        input! {
+            x: i32,
+        }
+        if x > 0 {
+            println!("x 10: {},", x * 10);
+        } else {
+            break;
+        }
+    }
+
+    // loop 式（break で値を返す方法）
+    let val = loop {
+        input! {
+            x: i32,
+        }
+        if x > 0 {
+            println!("^2: {},", x * x);
+        } else {
+            break x;
+        }
+    };
+    println!("break with {}", val)
 }

--- a/procon/loops_various/src/main.rs
+++ b/procon/loops_various/src/main.rs
@@ -1,3 +1,13 @@
 fn main() {
-    println!("Hello, world!");
+    let arr = [11, 12, 13, 14, 15, 16];
+    for &i in &arr {
+        if i == 12 {
+            continue;
+        }
+        if i == 14 {
+            break;
+        }
+        println!("{}, ", i);
+    }
+    println!("done");
 }

--- a/procon/loops_various/src/main.rs
+++ b/procon/loops_various/src/main.rs
@@ -14,6 +14,30 @@ fn main() {
     }
     println!("done");
 
+    // for 式 (二重ループ。ラベルなし)
+    for i in 0..6 {
+        for j in 0..i {
+            if i + j == 4 {
+                break;
+            }
+            print!("({0}, {1}) ", i ,j)
+        }
+        println!();
+    }
+
+    // for 式 (二重ループ。ラベルあり)
+    'outer_loop: for i in 0..6 {
+        for j in 0..i {
+            if i + j == 4 {
+                break 'outer_loop;
+            }
+            print!("({0}, {1}) ", i ,j)
+        }
+        println!();
+    }
+
+    println!();
+
     // `..` 演算子
     for i in 21..25 {
         println!("{},", i)
@@ -33,7 +57,7 @@ fn main() {
     println!("{:?},", vec);
 
     // loop 式
-    println!("loop:");
+    println!("loop: (x 10)");
     loop {
         input! {
             x: i32,
@@ -46,6 +70,7 @@ fn main() {
     }
 
     // loop 式（break で値を返す方法）
+    println!("loop: (square)");
     let val = loop {
         input! {
             x: i32,

--- a/procon/loops_various/src/main.rs
+++ b/procon/loops_various/src/main.rs
@@ -7,7 +7,14 @@ fn main() {
         if i == 14 {
             break;
         }
-        println!("{}, ", i);
+        println!("{},", i);
     }
     println!("done");
+
+    for i in 21..25 {
+        println!("{},", i)
+    }
+    for i in 31..=35 {
+        println!("{},", i)
+    }
 }


### PR DESCRIPTION
### preparation

```
% cd procon
% cargo new loops_various
```

### result

1. `cargo run`
1. 任意の正の整数を入力

```
...
loop: (x 10)
3
x 10: 30,
999
x 10: 9990,
0
...
```

```
...
loop: (square)
2
^2: 4,
8
^2: 64,
-1
break with -1
```

### ref

- https://zenn.dev/toga/books/rust-atcoder/viewer/20-loop
- https://github.com/miolab/rust_book/pull/12