### PR TITLE
slice, swap, reverse, sort お試し (cargo run)

### DIFF
--- a/procon/slice/Cargo.toml
+++ b/procon/slice/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "slice"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/procon/slice/src/main.rs
+++ b/procon/slice/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/procon/slice/src/main.rs
+++ b/procon/slice/src/main.rs
@@ -31,4 +31,38 @@ fn main() {
     assert_eq!(ref_partial_over_twenty[1], 40);
     assert_eq!(ref_partial_over_twenty[2], 50);
 
+    // スライスは for で走査できる
+    for i in &arr_for_partial_slice[..3] {
+        println!("{}", *i);
+    }
+
+    // swap 関数
+    let mut array_for_swap = [
+        0,
+        10,
+        20,
+        30,
+        40,
+    ];
+    let ref_for_swap = &mut array_for_swap[..];
+    ref_for_swap.swap(0, 3);
+    println!("swap:\n{:?}", array_for_swap);
+
+    // reverse 関数
+    let mut array_for_reverse = [
+        0,
+        10,
+        20,
+        30,
+        40,
+    ];
+    array_for_reverse.reverse();
+    println!("reverse (full):\n{:?}", array_for_reverse);
+
+    array_for_reverse[1..4].reverse();
+    println!("reverse (partial):\n{:?}", array_for_reverse);
+
+    // sort 関数
+    array_for_reverse.sort();
+    println!("sort:\n{:?}", array_for_reverse);
 }

--- a/procon/slice/src/main.rs
+++ b/procon/slice/src/main.rs
@@ -1,3 +1,14 @@
 fn main() {
-    println!("Hello, world!");
+    // スライス型 [T]
+    // - 配列 [T; N] の ; N を取り去った形
+    // - [T] 型の変数を宣言することはできない
+    let mut ref_slice: &[i32];
+
+    let array = [1, 2, 3];
+    ref_slice = &array;
+    println!("{:?}", ref_slice);
+
+    let vector = vec![4, 5, 6];
+    ref_slice = &vector;
+    println!("{:?}", ref_slice);
 }

--- a/procon/slice/src/main.rs
+++ b/procon/slice/src/main.rs
@@ -11,4 +11,24 @@ fn main() {
     let vector = vec![4, 5, 6];
     ref_slice = &vector;
     println!("{:?}", ref_slice);
+
+    // 部分スライス
+    let arr_for_partial_slice = [
+        0,
+        10,
+        20,
+        30,
+        40,
+        50,
+    ];
+    let ref_partial_slice = &arr_for_partial_slice[1..4];
+    assert_eq!(ref_partial_slice[0], 10);
+    assert_eq!(ref_partial_slice[1], 20);
+    assert_eq!(ref_partial_slice[2], 30);
+
+    let ref_partial_over_twenty = &arr_for_partial_slice[3..];
+    assert_eq!(ref_partial_over_twenty[0], 30);
+    assert_eq!(ref_partial_over_twenty[1], 40);
+    assert_eq!(ref_partial_over_twenty[2], 50);
+
 }


### PR DESCRIPTION
### preparation

```
% cd procon
% cargo new slice
```

### result

- `cargo run`
```
...
swap:
[30, 10, 20, 0, 40]
reverse (full):
[40, 30, 20, 10, 0]
reverse (partial):
[40, 10, 20, 30, 0]
sort:
[0, 10, 20, 30, 40]
```

### ref

- https://zenn.dev/toga/books/rust-atcoder/viewer/21-slice