### PR TITLE
文字列処理 (cargo run)

### DIFF
--- a/procon/string/Cargo.toml
+++ b/procon/string/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "string"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/procon/string/src/main.rs
+++ b/procon/string/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/procon/string/src/main.rs
+++ b/procon/string/src/main.rs
@@ -11,4 +11,22 @@ fn main() {
     let world = "world".to_string();
     // - 文字列リテラルを使う必要がある。println!(hello); とかはエラーになる。
     println!("{}, {}!", hello, world);
+
+    // chars 関数
+    for c in hello.chars() {
+        println!("{}", c);
+    }
+
+    let s_chars: &str = "打打打打打打打打";
+    // chars 型の文字リテラルは、1つの文字をシングルクォートで囲う
+    let da: char = '打';
+    for c in s_chars.chars() {
+        assert_eq!(c, da);
+    }
+
+    // bytes 関数
+    let s_bytes = "有難う";
+    for c in s_bytes.bytes() {
+        println!("{:x}", c);
+    }
 }

--- a/procon/string/src/main.rs
+++ b/procon/string/src/main.rs
@@ -29,4 +29,14 @@ fn main() {
     for c in s_bytes.bytes() {
         println!("{:x}", c);
     }
+
+    // to_string
+    let ten: i32 = 10;
+    assert_eq!(ten.to_string(), "10");
+
+    let float_num: f64 = 12.0;
+    assert_eq!(float_num.to_string(), "12");
+
+    let ace: char = 'A';
+    assert_eq!(ace.to_string(), "A");
 }

--- a/procon/string/src/main.rs
+++ b/procon/string/src/main.rs
@@ -39,4 +39,9 @@ fn main() {
 
     let ace: char = 'A';
     assert_eq!(ace.to_string(), "A");
+
+    // format! マクロ
+    println!("{0} {1}", 10, 2.5);
+    let s_format = format!("{0} {1}", 10, 2.5);
+    assert_eq!(s_format, "10 2.5");
 }

--- a/procon/string/src/main.rs
+++ b/procon/string/src/main.rs
@@ -1,3 +1,14 @@
 fn main() {
-    println!("Hello, world!");
+    // 文字列の型
+    // String (Vec<T> に相当)
+    let s = String::new();
+    // str (スライス [T] に相当)
+    let slice: &str = &s;
+    println!("{}", slice); // カラ出力
+
+    // 文字列出力
+    let hello = "Hello";
+    let world = "world".to_string();
+    // - 文字列リテラルを使う必要がある。println!(hello); とかはエラーになる。
+    println!("{}, {}!", hello, world);
 }


### PR DESCRIPTION
# preparation

```
% cd procon
% cargo new pattern_match_and_conditional
```

# result

- `cargo run`
```
Hello, world!
H
e
l
l
o
e6
9c
89
e9
9b
a3
e3
81
86
10 2.5
```

# ref

https://zenn.dev/toga/books/rust-atcoder/viewer/23-string
