### PR TITLE
参照渡し お試し (cargo run)

### DIFF
--- a/procon/call_by_reference/Cargo.toml
+++ b/procon/call_by_reference/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "call_by_reference"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/procon/call_by_reference/Cargo.toml
+++ b/procon/call_by_reference/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+proconio = "0.3.6"

--- a/procon/call_by_reference/src/main.rs
+++ b/procon/call_by_reference/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/procon/call_by_reference/src/main.rs
+++ b/procon/call_by_reference/src/main.rs
@@ -8,7 +8,16 @@ fn main() {
         "{:?} の総和は {}",
         vector,
         s
-    )
+    );
+
+    // 可変参照を渡す
+    let mut hoge = 10;
+    double(&mut hoge);
+    assert_eq!(hoge, 20);
+
+    let mut hoge = 10;
+    double(&mut hoge);
+    assert_eq!(hoge, 20);
 }
 
 // fn sum(v: Vec<i32>) -> i32 { // 値渡しになりエラー
@@ -19,4 +28,9 @@ fn sum(v: &Vec<i32>) -> i32 {
         ret += i;
     }
     ret
+}
+
+// 可変参照をとる関数
+fn double(x: &mut i32) {
+    *x *= 2;
 }

--- a/procon/call_by_reference/src/main.rs
+++ b/procon/call_by_reference/src/main.rs
@@ -1,3 +1,22 @@
 fn main() {
-    println!("Hello, world!");
+    // 参照渡し
+    let vector = vec![20, 80, 60, 40];
+    // let s = sum(vector); // 値渡しになりエラー
+    let s = sum(&vector);
+    assert_eq!(s, 200);
+    println!(
+        "{:?} の総和は {}",
+        vector,
+        s
+    )
+}
+
+// fn sum(v: Vec<i32>) -> i32 { // 値渡しになりエラー
+fn sum(v: &Vec<i32>) -> i32 {
+    let mut ret = 0;
+    // for &i in &v { // 値渡しになりエラー
+    for &i in v {
+        ret += i;
+    }
+    ret
 }

--- a/procon/call_by_reference/src/main.rs
+++ b/procon/call_by_reference/src/main.rs
@@ -28,7 +28,7 @@ fn main() {
     assert_eq!(x, 20);
     assert_eq!(y, 10);
 
-    proconio::input! {
+    input! {
         i: usize,
         j: usize,
     }
@@ -37,6 +37,8 @@ fn main() {
     // `std::mem::swap(&mut array[i], &mut array[j])` は不可
     array.swap(i, j);
     println!("{:?}", array);
+
+    print_with_debug();
 }
 
 // fn sum(v: Vec<i32>) -> i32 {... だと値渡しになってエラー
@@ -52,4 +54,14 @@ fn sum(v: &Vec<i32>) -> i32 {
 // 可変参照をとる関数
 fn double(x: &mut i32) {
     *x *= 2;
+}
+
+fn print_with_debug() {
+    let mut x = 0;
+    for i in 18..=20 {
+        x += i;
+        // dbg! ... 実行結果を一時的に出力する
+        dbg!(x);
+    }
+    println!("{}", x);
 }

--- a/procon/call_by_reference/src/main.rs
+++ b/procon/call_by_reference/src/main.rs
@@ -18,9 +18,16 @@ fn main() {
     let mut hoge = 10;
     double(&mut hoge);
     assert_eq!(hoge, 20);
+
+    // `std::mem::swap(&mut a, &mut )` 2つの可変参照を受け取って、その中身を入れ替える
+    let mut x = 10;
+    let mut y = 20;
+    std::mem::swap(&mut x, &mut y);
+    assert_eq!(x, 20);
+    assert_eq!(y, 10);
 }
 
-// fn sum(v: Vec<i32>) -> i32 { // 値渡しになりエラー
+// fn sum(v: Vec<i32>) -> i32 {... だと値渡しになってエラー
 fn sum(v: &Vec<i32>) -> i32 {
     let mut ret = 0;
     // for &i in &v { // 値渡しになりエラー

--- a/procon/call_by_reference/src/main.rs
+++ b/procon/call_by_reference/src/main.rs
@@ -1,3 +1,5 @@
+use proconio::input;
+
 fn main() {
     // 参照渡し
     let vector = vec![20, 80, 60, 40];
@@ -25,6 +27,16 @@ fn main() {
     std::mem::swap(&mut x, &mut y);
     assert_eq!(x, 20);
     assert_eq!(y, 10);
+
+    proconio::input! {
+        i: usize,
+        j: usize,
+    }
+    let mut array = [1, 2, 3, 4, 5];
+    // 配列やベクタの2つの要素を入れ替えるときは、swap 関数を使う
+    // `std::mem::swap(&mut array[i], &mut array[j])` は不可
+    array.swap(i, j);
+    println!("{:?}", array);
 }
 
 // fn sum(v: Vec<i32>) -> i32 {... だと値渡しになってエラー


### PR DESCRIPTION
# preparation

```
% cd procon
% cargo new call_by_reference
```

# result

1. `cargo run`
1.  `2, 5` 形式で数値入力  
  ... vector `[1, 2, 3, 4, 5]` の2つの要素を入れ替える
```
...
1 0
[2, 1, 3, 4, 5]
...
[src/main.rs:63] x = 18
[src/main.rs:63] x = 37
[src/main.rs:63] x = 57
57
```

# ref

https://zenn.dev/toga/books/rust-atcoder/viewer/26-call-by-reference

| 参照渡し/値渡し | 説明 |
|:--|:--|
| 引数の __参照渡し__| 引数として変数そのものの代わりに変数への参照を渡すこと |
| 引数の __値渡し__ | 変数そのものを渡すこと |